### PR TITLE
fix(wordpress): Improve HTTPS detection in wp-config.php

### DIFF
--- a/src/shipit/assets/wordpress/wp-config.php
+++ b/src/shipit/assets/wordpress/wp-config.php
@@ -126,6 +126,14 @@ define('LOGGED_IN_SALT', get_env_var('LOGGED_IN_SALT', 'no secret provided'));
 define('NONCE_SALT', get_env_var('NONCE_SALT', 'no secret provided'));
 
 
+if ( ! isset( $_SERVER['HTTPS'] )
+	&& isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] )
+	&& 'https' === strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] )
+) {
+	// We need to actually set it so WP would know it's behind TLS.
+	$_SERVER['HTTPS'] = '1';
+}
+
 $scheme = isset( $_SERVER['HTTPS'] ) && '1' === (string) $_SERVER['HTTPS'] ? "https://" : "http://";
 
 if (!defined('WP_HOME')) {


### PR DESCRIPTION
WordPress installed on new PHP versions returns following flags on server:
```
PHP_VERSION=8.3.21
SERVER
HTTPS=1
HTTP_X_FORWARDED_PROTO=https
REQUEST_SCHEME=(not set)
SERVER_PORT=8080
HTTP_HOST=wordpress-htxha.wasmer.app
WP_HOME=(not set)
```

but for the old one it returns different ones:
```
PHP_VERSION=7.4.33
SERVER
HTTPS=(not set)
HTTP_X_FORWARDED_PROTO=https
REQUEST_SCHEME=(not set)
SERVER_PORT=8080
HTTP_HOST=wordpress-vssa.wasmer.app
WP_HOME=(not set)
```

So we cannot rely on `HTTPS` alone, so this PR adds fallback to `HTTP_X_FORWARDED_PROTO` which should be always present.

Should fix issues with WP loading mixed content. 

Closes this one https://linear.app/wasmer/issue/ECO-144/wordpress-67-with-php-74-serves-http-assets