### PR TITLE
Add wp cron disable flag to wordpress config

### DIFF
--- a/src/shipit/assets/wordpress/wp-config.php
+++ b/src/shipit/assets/wordpress/wp-config.php
@@ -145,6 +145,7 @@ define( 'WP_SITEURL', get_env_var('WP_SITEURL', WP_HOME . '/') );
 define( 'WP_MEMORY_LIMIT', get_env_var('WP_MEMORY_LIMIT', '256M') );
 define( 'WP_MAX_MEMORY_LIMIT', get_env_var('WP_MAX_MEMORY_LIMIT', '256M') );
 define( 'WP_POST_REVISIONS', get_env_var('WP_POST_REVISIONS', false));
+define( 'DISABLE_WP_CRON', true );
 
 /**#@-*/
 


### PR DESCRIPTION
Set `DISABLE_WP_CRON` to `true` in the WordPress template config so automatic cron invocations stay disabled

Closes  https://linear.app/wasmer/issue/EDGE-1607/validate-that-wordpress-setup-actually-disables-automatic-cronjobs