### PR TITLE
ci: Add "publish on tag push" CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,89 +14,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Verify lockfile is up to date
-        run: uv lock --check
-
-      - name: Install dependencies
-        run: uv sync --locked --dev
-
-      - name: Bytecode compile check
-        run: uv run python -m compileall -q src tests
-
-      - name: Run mypy
-        run: uv run mypy
-
-      - name: Run tests (excluding e2e)
-        run: uv run pytest -m "not e2e" -q
-
-  e2e:
-    name: E2E (Python 3.13)
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    needs: test
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Set up Wasmer
-        uses: wasmerio/setup-wasmer@v3.1
-
-      - name: Verify toolchain
-        run: |
-          uv --version
-          python --version
-          wasmer --version
-          docker --version
-
-      - name: Install dependencies
-        run: uv sync --locked --dev
-
-      - name: Run e2e tests
-        run: |
-          uv run pytest -m e2e -v tests/test_e2e.py -n 4 \
-            -k "BuildMode.WasmerAndDocker and not cdn and not python-streamlit"
+  test_and_e2e:
+    name: Test + E2E
+    uses: ./.github/workflows/reusable-test-e2e.yml
 
   package:
     name: Build package
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - test
-      - e2e
+      - test_and_e2e
 
     steps:
       - name: Checkout

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,16 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_and_e2e:
-    name: Test + E2E
-    uses: ./.github/workflows/reusable-test-e2e.yml
-
-  publish:
-    name: Build and publish package
+  validate_version:
+    name: Validate tag and package versions
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs:
-      - test_and_e2e
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
@@ -81,6 +75,33 @@ jobs:
             echo "Version mismatch: src/shipit/version.py has '$SOURCE_VERSION' but tag is '$GIT_TAG' (expected '$TAG_VERSION')."
             exit 1
           fi
+
+  test_and_e2e:
+    name: Test + E2E
+    uses: ./.github/workflows/reusable-test-e2e.yml
+    needs:
+      - validate_version
+
+  publish:
+    name: Build and publish package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - test_and_e2e
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Build distribution
         run: uv build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,91 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test_and_e2e:
+    name: Test + E2E
+    uses: ./.github/workflows/reusable-test-e2e.yml
+
+  publish:
+    name: Build and publish package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - test_and_e2e
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Validate tag matches package versions
+        env:
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GIT_TAG" != v* ]]; then
+            echo "Tag '$GIT_TAG' does not start with 'v'."
+            exit 1
+          fi
+
+          TAG_VERSION="${GIT_TAG#v}"
+
+          PYPROJECT_VERSION=$(uv run python - <<'PY'
+          import pathlib
+          import tomllib
+
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          print(data["project"]["version"])
+          PY
+          )
+
+          SOURCE_VERSION=$(uv run python - <<'PY'
+          import pathlib
+          import re
+
+          content = pathlib.Path("src/shipit/version.py").read_text()
+          match = re.search(r'^version\\s*=\\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+          if not match:
+              raise SystemExit("Could not find version in src/shipit/version.py")
+          print(match.group(1))
+          PY
+          )
+
+          if [[ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]]; then
+            echo "Version mismatch: pyproject.toml has '$PYPROJECT_VERSION' but tag is '$GIT_TAG' (expected '$TAG_VERSION')."
+            exit 1
+          fi
+
+          if [[ "$SOURCE_VERSION" != "$TAG_VERSION" ]]; then
+            echo "Version mismatch: src/shipit/version.py has '$SOURCE_VERSION' but tag is '$GIT_TAG' (expected '$TAG_VERSION')."
+            exit 1
+          fi
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -112,4 +112,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_API_KEY }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -65,7 +65,7 @@ jobs:
           import re
 
           content = pathlib.Path("src/shipit/version.py").read_text()
-          match = re.search(r'^version\\s*=\\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+          match = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
           if not match:
               raise SystemExit("Could not find version in src/shipit/version.py")
           print(match.group(1))

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -88,6 +88,9 @@ jobs:
     timeout-minutes: 15
     needs:
       - test_and_e2e
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -1,0 +1,84 @@
+name: Reusable Test + E2E
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Verify lockfile is up to date
+        run: uv lock --check
+
+      - name: Install dependencies
+        run: uv sync --locked --dev
+
+      - name: Bytecode compile check
+        run: uv run python -m compileall -q src tests
+
+      - name: Run mypy
+        run: uv run mypy
+
+      - name: Run tests (excluding e2e)
+        run: uv run pytest -m "not e2e" -q
+
+  e2e:
+    name: E2E (Python 3.13)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Wasmer
+        uses: wasmerio/setup-wasmer@v3.1
+
+      - name: Verify toolchain
+        run: |
+          uv --version
+          python --version
+          wasmer --version
+          docker --version
+
+      - name: Install dependencies
+        run: uv sync --locked --dev
+
+      - name: Run e2e tests
+        run: |
+          uv run pytest -m e2e -v tests/test_e2e.py -n 4 \
+            -k "BuildMode.WasmerAndDocker and not cdn and not python-streamlit"

--- a/README.md
+++ b/README.md
@@ -110,3 +110,20 @@ The e2e tests will:
 * Build the project (locally, or with docker)
 * Run the project (locally or with Wasmer)
 * Test that the project output (via http requests) is the correct one
+
+### Automatic PyPI Publish
+
+Publishing to PyPI is automated with GitHub Actions on version tags.
+
+Requirements:
+
+* Add a repository secret named `PYPI_API_TOKEN` with a PyPI API token.
+* Push tags using the `vX.Y.Z` format (for example: `v0.17.5`).
+
+On each `v*` tag push, the workflow:
+
+* Runs regular test and e2e workflows.
+* Validates that the tag version without the leading `v` matches:
+  * `project.version` in `pyproject.toml`
+  * `version` in `src/shipit/version.py`
+* Builds the package and publishes to PyPI only if all checks pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shipit-cli"
-version = "0.17.6"
+version = "0.17.7.alpha-1"
 description = "Shipit CLI is the best way to build, serve and deploy your projects anywhere."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/shipit/version.py
+++ b/src/shipit/version.py
@@ -1,5 +1,5 @@
 __all__ = ["version", "version_info"]
 
 
-version = "0.17.6"
+version = "0.17.7.alpha-1"
 version_info = (0, 17, 6, "final", 0)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -1105,7 +1105,7 @@ wheels = [
 
 [[package]]
 name = "shipit-cli"
-version = "0.17.6"
+version = "0.17.7a1"
 source = { editable = "." }
 dependencies = [
     { name = "dotenv" },


### PR DESCRIPTION
When pushing a tag the package will be built and published to PyPI.
Note: Version in tag must match tag, with v<version> format.
