### PR TITLE
Add wp command to wordpress packages and remove the wp() bash function

### DIFF
--- a/src/shipit/assets/wordpress/install.sh
+++ b/src/shipit/assets/wordpress/install.sh
@@ -11,10 +11,6 @@ WP_LOCALE=${WP_LOCALE:-"en_US"}
 WP_SITEURL=${WP_SITEURL:-"http://localhost"}
 WP_SITE_TITLE=${WP_SITE_TITLE:-"WordPress"}
 
-wp() {
-  php /opt/assets/wp-cli.phar --allow-root --path=/app "$@"
-}
-
 echo "🚀 Starting WordPress setup..."
 
 echo "Creating required directories..."

--- a/src/shipit/providers/wordpress.py
+++ b/src/shipit/providers/wordpress.py
@@ -90,7 +90,7 @@ class WordPressProvider(PhpProvider):
                     '-t {}".format(assets.serve_path, PORT, app.serve_path)'
                 )
         return {
-            # "wp": '"php {}/wp-cli.phar --allow-root --path={}".format(assets.serve_path, app.serve_path)',
+            "wp": '"php {}/wp-cli.phar --allow-root --path={}".format(assets.serve_path, app.serve_path)',
             "after_deploy": '"bash {}/setup-wp.sh".format(assets.serve_path)',
             **commands,
         }


### PR DESCRIPTION
Following the addition of Mount FS in wasmer, we can now enable the `wp` command at the package level for use in setup scripts and SSH sessions.