### PR TITLE
fix(release): prevent draft release PR race

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,12 +27,21 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
-      - name: Create or update release PR
+      - name: Create release from merged release PR
         id: release
         uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo-url: ${{ github.repository }}
+          skip-github-pull-request: true
+
+      - name: Create or update release PR
+        if: steps.release.outputs.release_created != 'true'
+        uses: googleapis/release-please-action@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo-url: ${{ github.repository }}
+          skip-github-release: true
 
   release_artifacts:
     name: Build release artifacts

--- a/crates/anybuild/tests/release_config.rs
+++ b/crates/anybuild/tests/release_config.rs
@@ -57,3 +57,35 @@ fn release_please_tracks_one_workspace_release() {
         .collect::<BTreeSet<_>>();
     assert_eq!(manifest_paths, BTreeSet::from(["."]));
 }
+
+#[test]
+fn release_workflow_does_not_create_a_release_and_next_pr_together() {
+    let workflow_path = workspace_root().join(".github/workflows/release-please.yml");
+    let workflow = fs::read_to_string(&workflow_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", workflow_path.display()));
+
+    assert_eq!(
+        workflow
+            .matches("uses: googleapis/release-please-action@v5")
+            .count(),
+        2,
+        "release creation and release-PR generation need separate invocations"
+    );
+    let (release_step, pr_step) = workflow
+        .split_once("      - name: Create or update release PR")
+        .expect("release workflow should have a distinct release-PR step");
+    assert!(
+        release_step.contains("      - name: Create release from merged release PR")
+            && release_step.contains("id: release")
+            && release_step.contains("skip-github-pull-request: true"),
+        "the release invocation must not generate the next release PR"
+    );
+    assert!(
+        pr_step.contains("if: steps.release.outputs.release_created != 'true'"),
+        "release-PR generation must be skipped while a draft release is created"
+    );
+    assert!(
+        pr_step.contains("skip-github-release: true"),
+        "the release-PR invocation must not create a GitHub release"
+    );
+}


### PR DESCRIPTION
## Summary

- separate GitHub release creation from release-PR generation
- skip release-PR generation whenever the same workflow created a draft release
- make the PR-only invocation incapable of creating a release
- add a regression test that enforces the two-invocation workflow

## Why

Release Please cannot discover a newly created draft release while it builds the next release PR in the same invocation. That race created invalid PRs #79, #82 from already released commits.

## Validation

- `cargo test -p anybuild --test release_config`
- workflow YAML parses successfully
- Release Please 17.6.0 remote dry-run recognizes published `v0.26.2`, sees zero commits after it, and would open zero PRs