### PR TITLE
Improved environment reading

### DIFF
--- a/crates/anybuild/src/providers/environment.rs
+++ b/crates/anybuild/src/providers/environment.rs
@@ -1,85 +1,76 @@
-//! Environment overrides expressed as candidate JSON values.
-//!
-//! Serialized `Option<T>` values lose their type when they are `null`. For
-//! those fields, an environment value can have more than one reasonable JSON
-//! representation. This module only builds those representations; the
-//! provider boundary remains responsible for deserializing them.
+//! Environment overrides for serialized provider configurations.
 
 use anyhow::{anyhow, Result};
-use serde_json::{Map, Value};
 
+use super::{config_from_json, ProviderConfig};
 use crate::operation::OperationContext;
 
-pub(super) struct FieldOverride {
-    pub field: String,
-    pub candidates: Vec<Value>,
-}
-
-pub(super) struct EnvironmentOverlay {
-    pub fields: Map<String, Value>,
-    pub overrides: Vec<FieldOverride>,
-    pub applied: Option<(String, String)>,
-}
-
-pub(super) fn apply(json: Value, operation: &OperationContext) -> Result<EnvironmentOverlay> {
-    let mut fields = json
-        .as_object()
-        .cloned()
-        .ok_or_else(|| anyhow!("provider config did not serialize to an object"))?;
-    let mut overrides = Vec::new();
+pub(crate) fn apply_environment(
+    config: ProviderConfig,
+    operation: &OperationContext,
+) -> Result<ProviderConfig> {
+    let provider = config.provider_name();
+    let mut json = config.to_json();
+    let fields = json
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("{provider} config did not serialize to an object"))?;
     let mut applied = None;
-
-    for (field, current) in &mut fields {
-        let Some((name, raw)) = environment_value(operation, field) else {
+    for field in fields.keys().cloned().collect::<Vec<_>>() {
+        let upper = field.to_ascii_uppercase();
+        let anybuild = format!("ANYBUILD_{upper}");
+        let shipit = format!("SHIPIT_{upper}");
+        let Some((name, raw)) = operation
+            .environment_var(&anybuild)
+            .map(|value| (anybuild, value))
+            .or_else(|| {
+                operation
+                    .environment_var(&shipit)
+                    .map(|value| (shipit, value))
+            })
+            .or_else(|| {
+                (field == "port")
+                    .then(|| {
+                        operation
+                            .environment_var("PORT")
+                            .map(|value| ("PORT".into(), value))
+                    })
+                    .flatten()
+            })
+        else {
             continue;
         };
-        let candidates = if current.is_null() {
-            untyped_candidates(&raw)
+        let current = fields.get(&field).cloned().unwrap_or_default();
+        let value = if current.is_null() {
+            resolve_untyped_environment_value(&raw, |candidate| {
+                let mut probe = fields.clone();
+                probe.insert(field.clone(), candidate.clone());
+                config_from_json(provider, serde_json::Value::Object(probe)).is_ok()
+            })
         } else {
-            vec![parse_typed_value(&name, &raw, current)?]
+            parse_environment_value(&name, &raw, &current)?
         };
-        overrides.push(FieldOverride {
-            field: field.clone(),
-            candidates,
-        });
+        fields.insert(field, value);
         applied = Some((name, raw));
     }
-
-    Ok(EnvironmentOverlay {
-        fields,
-        overrides,
-        applied,
-    })
+    let mut updated = config_from_json(provider, serde_json::Value::Object(fields.clone()))
+        .map_err(|error| match applied {
+            Some((name, raw)) => anyhow!("Invalid value for {name}: {raw:?}: {error}"),
+            None => error,
+        })?;
+    updated.copy_transient_fields_from(&config);
+    Ok(updated)
 }
 
-fn environment_value(operation: &OperationContext, field: &str) -> Option<(String, String)> {
-    let upper = field.to_ascii_uppercase();
-    let anybuild = format!("ANYBUILD_{upper}");
-    let shipit = format!("SHIPIT_{upper}");
-    operation
-        .environment_var(&anybuild)
-        .map(|value| (anybuild, value))
-        .or_else(|| {
-            operation
-                .environment_var(&shipit)
-                .map(|value| (shipit, value))
-        })
-        .or_else(|| {
-            (field == "port")
-                .then(|| {
-                    operation
-                        .environment_var("PORT")
-                        .map(|value| ("PORT".into(), value))
-                })
-                .flatten()
-        })
-}
-
-fn parse_typed_value(name: &str, raw: &str, current: &Value) -> Result<Value> {
+fn parse_environment_value(
+    name: &str,
+    raw: &str,
+    current: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    use serde_json::Value;
     let invalid =
         |expected: &str| anyhow!("Invalid value for {name}: {raw:?}; expected {expected}");
     match current {
-        Value::Bool(_) => parse_bool(raw)
+        Value::Bool(_) => parse_environment_bool(raw)
             .map(Value::Bool)
             .ok_or_else(|| invalid("a boolean")),
         Value::Number(number) if number.is_i64() || number.is_u64() => raw
@@ -97,25 +88,28 @@ fn parse_typed_value(name: &str, raw: &str, current: &Value) -> Result<Value> {
             serde_json::from_str(raw).map_err(|_| invalid("valid JSON"))
         }
         Value::String(_) => Ok(Value::String(raw.to_owned())),
-        Value::Null => unreachable!("null values have no type to parse against"),
+        Value::Null => unreachable!("untyped values are resolved before parsing"),
     }
 }
 
-/// Return plausible JSON readings in preference order. The provider's normal
-/// deserializer decides which reading matches the field's erased `Option<T>`.
-fn untyped_candidates(raw: &str) -> Vec<Value> {
-    let mut candidates = Vec::new();
-    if let Ok(parsed) = serde_json::from_str::<Value>(raw) {
-        candidates.push(parsed);
-    }
-    if let Some(boolean) = parse_bool(raw) {
-        push_unique(&mut candidates, Value::Bool(boolean));
-    }
-    push_unique(&mut candidates, Value::String(raw.to_owned()));
-    candidates
+/// Choose a JSON representation without coupling environment parsing to a
+/// particular schema or deserializer.
+fn resolve_untyped_environment_value(
+    raw: &str,
+    accepts: impl Fn(&serde_json::Value) -> bool,
+) -> serde_json::Value {
+    use serde_json::Value;
+    let string = Value::String(raw.to_owned());
+    let json = serde_json::from_str::<Value>(raw).ok();
+    let fallback = json.clone().unwrap_or_else(|| string.clone());
+    json.into_iter()
+        .chain(parse_environment_bool(raw).map(Value::Bool))
+        .chain([string])
+        .find(|candidate| accepts(candidate))
+        .unwrap_or(fallback)
 }
 
-fn parse_bool(raw: &str) -> Option<bool> {
+fn parse_environment_bool(raw: &str) -> Option<bool> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "true" | "t" | "yes" | "y" | "on" | "1" => Some(true),
         "false" | "f" | "no" | "n" | "off" | "0" => Some(false),
@@ -123,8 +117,74 @@ fn parse_bool(raw: &str) -> Option<bool> {
     }
 }
 
-fn push_unique(values: &mut Vec<Value>, value: Value) {
-    if !values.contains(&value) {
-        values.push(value);
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::event::{ProcessIo, Reporter};
+    use crate::providers::wordpress;
+
+    fn apply(config: ProviderConfig, name: &str, value: &str) -> Result<serde_json::Value> {
+        let environment: IndexMap<String, String> =
+            [(name.to_owned(), value.to_owned())].into_iter().collect();
+        // Do not let unrelated ANYBUILD_* variables in the developer's shell
+        // affect these overlay tests.
+        let operation =
+            OperationContext::new(environment, false, ProcessIo::Inherit, Reporter::default());
+        apply_environment(config, &operation).map(|config| config.to_json())
+    }
+
+    /// An `Option<bool>` left unset serializes to `null`, which carries no
+    /// type. It must still accept every boolean spelling a set `bool` does,
+    /// rather than reading `1` as an integer and rejecting it.
+    #[test]
+    fn unset_optional_bool_accepts_numeric_booleans() {
+        for (raw, expected) in [
+            ("1", true),
+            ("0", false),
+            ("true", true),
+            ("false", false),
+            ("yes", true),
+            ("off", false),
+        ] {
+            let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+            assert_eq!(config.to_json()["phpix"], serde_json::Value::Null);
+            let json = apply(config, "ANYBUILD_PHPIX", raw)
+                .unwrap_or_else(|error| panic!("ANYBUILD_PHPIX={raw}: {error}"));
+            assert_eq!(json["phpix"], serde_json::json!(expected), "PHPIX={raw}");
+        }
+    }
+
+    /// The legacy prefix reaches the same overlay, so it needs the same
+    /// coercion.
+    #[test]
+    fn unset_optional_bool_accepts_numeric_booleans_via_legacy_prefix() {
+        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+        let json = apply(config, "SHIPIT_PHPIX", "1").expect("SHIPIT_PHPIX=1 is accepted");
+        assert_eq!(json["phpix"], serde_json::json!(true));
+    }
+
+    /// A value that parses as JSON of the wrong type must not win over the
+    /// literal string an unset `Option<String>` expects.
+    #[test]
+    fn unset_optional_string_keeps_numeric_looking_values_as_strings() {
+        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+        let json = apply(config, "ANYBUILD_WP_VERSION", "6.4").expect("WP_VERSION=6.4 is accepted");
+        assert_eq!(json["wp_version"], serde_json::json!("6.4"));
+    }
+
+    /// Coercion must not swallow genuinely malformed input.
+    #[test]
+    fn unset_optional_bool_still_rejects_non_boolean_values() {
+        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+        let error =
+            apply(config, "ANYBUILD_PHPIX", "enabled").expect_err("PHPIX=enabled is not a boolean");
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid value for ANYBUILD_PHPIX"),
+            "{error}"
+        );
     }
 }

--- a/crates/anybuild/src/providers/environment.rs
+++ b/crates/anybuild/src/providers/environment.rs
@@ -1,0 +1,130 @@
+//! Environment overrides expressed as candidate JSON values.
+//!
+//! Serialized `Option<T>` values lose their type when they are `null`. For
+//! those fields, an environment value can have more than one reasonable JSON
+//! representation. This module only builds those representations; the
+//! provider boundary remains responsible for deserializing them.
+
+use anyhow::{anyhow, Result};
+use serde_json::{Map, Value};
+
+use crate::operation::OperationContext;
+
+pub(super) struct FieldOverride {
+    pub field: String,
+    pub candidates: Vec<Value>,
+}
+
+pub(super) struct EnvironmentOverlay {
+    pub fields: Map<String, Value>,
+    pub overrides: Vec<FieldOverride>,
+    pub applied: Option<(String, String)>,
+}
+
+pub(super) fn apply(json: Value, operation: &OperationContext) -> Result<EnvironmentOverlay> {
+    let mut fields = json
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow!("provider config did not serialize to an object"))?;
+    let mut overrides = Vec::new();
+    let mut applied = None;
+
+    for (field, current) in &mut fields {
+        let Some((name, raw)) = environment_value(operation, field) else {
+            continue;
+        };
+        let candidates = if current.is_null() {
+            untyped_candidates(&raw)
+        } else {
+            vec![parse_typed_value(&name, &raw, current)?]
+        };
+        overrides.push(FieldOverride {
+            field: field.clone(),
+            candidates,
+        });
+        applied = Some((name, raw));
+    }
+
+    Ok(EnvironmentOverlay {
+        fields,
+        overrides,
+        applied,
+    })
+}
+
+fn environment_value(operation: &OperationContext, field: &str) -> Option<(String, String)> {
+    let upper = field.to_ascii_uppercase();
+    let anybuild = format!("ANYBUILD_{upper}");
+    let shipit = format!("SHIPIT_{upper}");
+    operation
+        .environment_var(&anybuild)
+        .map(|value| (anybuild, value))
+        .or_else(|| {
+            operation
+                .environment_var(&shipit)
+                .map(|value| (shipit, value))
+        })
+        .or_else(|| {
+            (field == "port")
+                .then(|| {
+                    operation
+                        .environment_var("PORT")
+                        .map(|value| ("PORT".into(), value))
+                })
+                .flatten()
+        })
+}
+
+fn parse_typed_value(name: &str, raw: &str, current: &Value) -> Result<Value> {
+    let invalid =
+        |expected: &str| anyhow!("Invalid value for {name}: {raw:?}; expected {expected}");
+    match current {
+        Value::Bool(_) => parse_bool(raw)
+            .map(Value::Bool)
+            .ok_or_else(|| invalid("a boolean")),
+        Value::Number(number) if number.is_i64() || number.is_u64() => raw
+            .trim()
+            .parse::<i64>()
+            .map(|value| Value::Number(value.into()))
+            .map_err(|_| invalid("an integer")),
+        Value::Number(_) => {
+            let value = raw.trim().parse::<f64>().map_err(|_| invalid("a number"))?;
+            serde_json::Number::from_f64(value)
+                .map(Value::Number)
+                .ok_or_else(|| invalid("a finite number"))
+        }
+        Value::Array(_) | Value::Object(_) => {
+            serde_json::from_str(raw).map_err(|_| invalid("valid JSON"))
+        }
+        Value::String(_) => Ok(Value::String(raw.to_owned())),
+        Value::Null => unreachable!("null values have no type to parse against"),
+    }
+}
+
+/// Return plausible JSON readings in preference order. The provider's normal
+/// deserializer decides which reading matches the field's erased `Option<T>`.
+fn untyped_candidates(raw: &str) -> Vec<Value> {
+    let mut candidates = Vec::new();
+    if let Ok(parsed) = serde_json::from_str::<Value>(raw) {
+        candidates.push(parsed);
+    }
+    if let Some(boolean) = parse_bool(raw) {
+        push_unique(&mut candidates, Value::Bool(boolean));
+    }
+    push_unique(&mut candidates, Value::String(raw.to_owned()));
+    candidates
+}
+
+fn parse_bool(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "t" | "yes" | "y" | "on" | "1" => Some(true),
+        "false" | "f" | "no" | "n" | "off" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+fn push_unique(values: &mut Vec<Value>, value: Value) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}

--- a/crates/anybuild/src/providers/mod.rs
+++ b/crates/anybuild/src/providers/mod.rs
@@ -13,6 +13,7 @@ use crate::event::ProviderDetail;
 use crate::operation::OperationContext;
 
 pub mod base;
+mod environment;
 pub mod go;
 pub mod hugo;
 pub mod install_context;
@@ -607,40 +608,10 @@ pub(crate) fn apply_environment(
     operation: &OperationContext,
 ) -> Result<ProviderConfig> {
     let provider = config.provider_name();
-    let mut json = config.to_json();
-    let fields = json
-        .as_object_mut()
-        .ok_or_else(|| anyhow!("{provider} config did not serialize to an object"))?;
-    let mut applied = None;
-    for (field, current) in fields.iter_mut() {
-        let upper = field.to_ascii_uppercase();
-        let anybuild = format!("ANYBUILD_{upper}");
-        let shipit = format!("SHIPIT_{upper}");
-        let Some((name, raw)) = operation
-            .environment_var(&anybuild)
-            .map(|value| (anybuild, value))
-            .or_else(|| {
-                operation
-                    .environment_var(&shipit)
-                    .map(|value| (shipit, value))
-            })
-            .or_else(|| {
-                (field == "port")
-                    .then(|| {
-                        operation
-                            .environment_var("PORT")
-                            .map(|value| ("PORT".into(), value))
-                    })
-                    .flatten()
-            })
-        else {
-            continue;
-        };
-        *current = parse_environment_value(&name, &raw, current)?;
-        applied = Some((name, raw));
-    }
-    let mut updated = config_from_json(provider, serde_json::Value::Object(fields.clone()))
-        .map_err(|error| match applied {
+    let overlay = environment::apply(config.to_json(), operation)?;
+    let applied = overlay.applied.clone();
+    let mut updated =
+        deserialize_environment_overlay(provider, overlay).map_err(|error| match applied {
             Some((name, raw)) => anyhow!("Invalid value for {name}: {raw:?}: {error}"),
             None => error,
         })?;
@@ -648,37 +619,28 @@ pub(crate) fn apply_environment(
     Ok(updated)
 }
 
-fn parse_environment_value(
-    name: &str,
-    raw: &str,
-    current: &serde_json::Value,
-) -> Result<serde_json::Value> {
-    use serde_json::Value;
-    let invalid =
-        |expected: &str| anyhow!("Invalid value for {name}: {raw:?}; expected {expected}");
-    match current {
-        Value::Bool(_) => match raw.trim().to_ascii_lowercase().as_str() {
-            "true" | "t" | "yes" | "y" | "on" | "1" => Ok(Value::Bool(true)),
-            "false" | "f" | "no" | "n" | "off" | "0" => Ok(Value::Bool(false)),
-            _ => Err(invalid("a boolean")),
-        },
-        Value::Number(number) if number.is_i64() || number.is_u64() => raw
-            .trim()
-            .parse::<i64>()
-            .map(|value| Value::Number(value.into()))
-            .map_err(|_| invalid("an integer")),
-        Value::Number(_) => {
-            let value = raw.trim().parse::<f64>().map_err(|_| invalid("a number"))?;
-            serde_json::Number::from_f64(value)
-                .map(Value::Number)
-                .ok_or_else(|| invalid("a finite number"))
-        }
-        Value::Array(_) | Value::Object(_) => {
-            serde_json::from_str(raw).map_err(|_| invalid("valid JSON"))
-        }
-        Value::String(_) => Ok(Value::String(raw.to_owned())),
-        Value::Null => Ok(serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.into()))),
+/// Resolve erased `Option<T>` types at the provider deserialization boundary.
+/// Environment parsing remains independent of every concrete config type.
+fn deserialize_environment_overlay(
+    provider: &str,
+    mut overlay: environment::EnvironmentOverlay,
+) -> Result<ProviderConfig> {
+    for field_override in overlay.overrides {
+        let Some(fallback) = field_override.candidates.first().cloned() else {
+            continue;
+        };
+        let selected = field_override
+            .candidates
+            .into_iter()
+            .find(|candidate| {
+                let mut probe = overlay.fields.clone();
+                probe.insert(field_override.field.clone(), candidate.clone());
+                config_from_json(provider, serde_json::Value::Object(probe)).is_ok()
+            })
+            .unwrap_or(fallback);
+        overlay.fields.insert(field_override.field, selected);
     }
+    config_from_json(provider, serde_json::Value::Object(overlay.fields))
 }
 
 /// Apply a provider's declared defaults to an already serialized config.
@@ -731,6 +693,77 @@ pub fn config_from_json(name: &str, json: serde_json::Value) -> Result<ProviderC
     ProviderKind::from_name(name)
         .ok_or_else(|| anyhow!("unknown provider {name:?}"))?
         .config_from_json(json)
+}
+
+#[cfg(test)]
+mod environment_overlay_tests {
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::event::{ProcessIo, Reporter};
+
+    fn apply(config: ProviderConfig, name: &str, value: &str) -> Result<serde_json::Value> {
+        let environment: IndexMap<String, String> =
+            [(name.to_owned(), value.to_owned())].into_iter().collect();
+        // Do not let unrelated ANYBUILD_* variables in the developer's shell
+        // affect these overlay tests.
+        let operation =
+            OperationContext::new(environment, false, ProcessIo::Inherit, Reporter::default());
+        apply_environment(config, &operation).map(|config| config.to_json())
+    }
+
+    /// An `Option<bool>` left unset serializes to `null`, which carries no
+    /// type. It must still accept every boolean spelling a set `bool` does,
+    /// rather than reading `1` as an integer and rejecting it.
+    #[test]
+    fn unset_optional_bool_accepts_numeric_booleans() {
+        for (raw, expected) in [
+            ("1", true),
+            ("0", false),
+            ("true", true),
+            ("false", false),
+            ("yes", true),
+            ("off", false),
+        ] {
+            let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+            assert_eq!(config.to_json()["phpix"], serde_json::Value::Null);
+            let json = apply(config, "ANYBUILD_PHPIX", raw)
+                .unwrap_or_else(|error| panic!("ANYBUILD_PHPIX={raw}: {error}"));
+            assert_eq!(json["phpix"], serde_json::json!(expected), "PHPIX={raw}");
+        }
+    }
+
+    /// The legacy prefix reaches the same overlay, so it needs the same
+    /// coercion.
+    #[test]
+    fn unset_optional_bool_accepts_numeric_booleans_via_legacy_prefix() {
+        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+        let json = apply(config, "SHIPIT_PHPIX", "1").expect("SHIPIT_PHPIX=1 is accepted");
+        assert_eq!(json["phpix"], serde_json::json!(true));
+    }
+
+    /// A value that parses as JSON of the wrong type must not win over the
+    /// literal string an unset `Option<String>` expects.
+    #[test]
+    fn unset_optional_string_keeps_numeric_looking_values_as_strings() {
+        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+        let json = apply(config, "ANYBUILD_WP_VERSION", "6.4").expect("WP_VERSION=6.4 is accepted");
+        assert_eq!(json["wp_version"], serde_json::json!("6.4"));
+    }
+
+    /// Coercion must not swallow genuinely malformed input.
+    #[test]
+    fn unset_optional_bool_still_rejects_non_boolean_values() {
+        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
+        let error =
+            apply(config, "ANYBUILD_PHPIX", "enabled").expect_err("PHPIX=enabled is not a boolean");
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid value for ANYBUILD_PHPIX"),
+            "{error}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/anybuild/src/providers/mod.rs
+++ b/crates/anybuild/src/providers/mod.rs
@@ -30,6 +30,7 @@ pub mod wordpress;
 pub mod workspace;
 
 pub use base::{BaseConfig, HasBase};
+pub(crate) use environment::apply_environment;
 
 const SNAPSHOT_EXCLUDED_FIELDS: &[&str] = &[
     "name",
@@ -603,46 +604,6 @@ pub(crate) fn load_explicit_provider(
         .with_context(|| format!("loading {name} config"))
 }
 
-pub(crate) fn apply_environment(
-    config: ProviderConfig,
-    operation: &OperationContext,
-) -> Result<ProviderConfig> {
-    let provider = config.provider_name();
-    let overlay = environment::apply(config.to_json(), operation)?;
-    let applied = overlay.applied.clone();
-    let mut updated =
-        deserialize_environment_overlay(provider, overlay).map_err(|error| match applied {
-            Some((name, raw)) => anyhow!("Invalid value for {name}: {raw:?}: {error}"),
-            None => error,
-        })?;
-    updated.copy_transient_fields_from(&config);
-    Ok(updated)
-}
-
-/// Resolve erased `Option<T>` types at the provider deserialization boundary.
-/// Environment parsing remains independent of every concrete config type.
-fn deserialize_environment_overlay(
-    provider: &str,
-    mut overlay: environment::EnvironmentOverlay,
-) -> Result<ProviderConfig> {
-    for field_override in overlay.overrides {
-        let Some(fallback) = field_override.candidates.first().cloned() else {
-            continue;
-        };
-        let selected = field_override
-            .candidates
-            .into_iter()
-            .find(|candidate| {
-                let mut probe = overlay.fields.clone();
-                probe.insert(field_override.field.clone(), candidate.clone());
-                config_from_json(provider, serde_json::Value::Object(probe)).is_ok()
-            })
-            .unwrap_or(fallback);
-        overlay.fields.insert(field_override.field, selected);
-    }
-    config_from_json(provider, serde_json::Value::Object(overlay.fields))
-}
-
 /// Apply a provider's declared defaults to an already serialized config.
 /// This is used by the Wasmer runner after applying runtime overrides.
 pub fn exclude_defaults_from_json(name: &str, dumped: serde_json::Value) -> serde_json::Value {
@@ -693,77 +654,6 @@ pub fn config_from_json(name: &str, json: serde_json::Value) -> Result<ProviderC
     ProviderKind::from_name(name)
         .ok_or_else(|| anyhow!("unknown provider {name:?}"))?
         .config_from_json(json)
-}
-
-#[cfg(test)]
-mod environment_overlay_tests {
-    use indexmap::IndexMap;
-
-    use super::*;
-    use crate::event::{ProcessIo, Reporter};
-
-    fn apply(config: ProviderConfig, name: &str, value: &str) -> Result<serde_json::Value> {
-        let environment: IndexMap<String, String> =
-            [(name.to_owned(), value.to_owned())].into_iter().collect();
-        // Do not let unrelated ANYBUILD_* variables in the developer's shell
-        // affect these overlay tests.
-        let operation =
-            OperationContext::new(environment, false, ProcessIo::Inherit, Reporter::default());
-        apply_environment(config, &operation).map(|config| config.to_json())
-    }
-
-    /// An `Option<bool>` left unset serializes to `null`, which carries no
-    /// type. It must still accept every boolean spelling a set `bool` does,
-    /// rather than reading `1` as an integer and rejecting it.
-    #[test]
-    fn unset_optional_bool_accepts_numeric_booleans() {
-        for (raw, expected) in [
-            ("1", true),
-            ("0", false),
-            ("true", true),
-            ("false", false),
-            ("yes", true),
-            ("off", false),
-        ] {
-            let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
-            assert_eq!(config.to_json()["phpix"], serde_json::Value::Null);
-            let json = apply(config, "ANYBUILD_PHPIX", raw)
-                .unwrap_or_else(|error| panic!("ANYBUILD_PHPIX={raw}: {error}"));
-            assert_eq!(json["phpix"], serde_json::json!(expected), "PHPIX={raw}");
-        }
-    }
-
-    /// The legacy prefix reaches the same overlay, so it needs the same
-    /// coercion.
-    #[test]
-    fn unset_optional_bool_accepts_numeric_booleans_via_legacy_prefix() {
-        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
-        let json = apply(config, "SHIPIT_PHPIX", "1").expect("SHIPIT_PHPIX=1 is accepted");
-        assert_eq!(json["phpix"], serde_json::json!(true));
-    }
-
-    /// A value that parses as JSON of the wrong type must not win over the
-    /// literal string an unset `Option<String>` expects.
-    #[test]
-    fn unset_optional_string_keeps_numeric_looking_values_as_strings() {
-        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
-        let json = apply(config, "ANYBUILD_WP_VERSION", "6.4").expect("WP_VERSION=6.4 is accepted");
-        assert_eq!(json["wp_version"], serde_json::json!("6.4"));
-    }
-
-    /// Coercion must not swallow genuinely malformed input.
-    #[test]
-    fn unset_optional_bool_still_rejects_non_boolean_values() {
-        let config = ProviderConfig::Wordpress(wordpress::WordPressConfig::default());
-        let error =
-            apply(config, "ANYBUILD_PHPIX", "enabled").expect_err("PHPIX=enabled is not a boolean");
-        assert!(
-            error
-                .to_string()
-                .contains("Invalid value for ANYBUILD_PHPIX"),
-            "{error}"
-        );
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a revamp of #85 but with the logic moved into environment parsing, which should be a bit cleaner.

All tests remain the same