### PR TITLE
feat: allow overriding the default Python index

### DIFF
--- a/crates/anybuild/resources/starlib/tools/python.bzl
+++ b/crates/anybuild/resources/starlib/tools/python.bzl
@@ -78,19 +78,20 @@ def _cross_wheel_steps(config, venv, local_venv):
     python_version = config.python_version
     extra = ", ".join(config.python_extra_dependencies)
     index = config.python_extra_index_url
+    default_index = config.python_index_url or "https://pypi.org/simple"
     all_files = config.python_install_requires_all_files
     in_subdir = config.app_subdir != None
     cross_packages = "{}/lib/python{}/site-packages".format(venv.path, python_version)
 
     if file_exists("pyproject.toml"):
         compile_step = run(
-            "uv pip compile pyproject.toml --universal --extra-index-url {} --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt".format(index),
+            "uv pip compile pyproject.toml --universal --extra-index-url {} --default-index {} --emit-index-url --no-deps -o cross-requirements.txt".format(index, default_index),
             outputs = ["cross-requirements.txt"],
         )
     else:
         inputs = None if (in_subdir or all_files) else config.python_install_inputs
         compile_step = run(
-            "uv pip compile requirements.txt --python-version={} --universal --extra-index-url {} --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt".format(python_version, index),
+            "uv pip compile requirements.txt --python-version={} --universal --extra-index-url {} --default-index {} --emit-index-url --no-deps -o cross-requirements.txt".format(python_version, index, default_index),
             inputs = inputs,
             outputs = ["cross-requirements.txt"],
         )

--- a/crates/anybuild/src/providers/mkdocs.rs
+++ b/crates/anybuild/src/providers/mkdocs.rs
@@ -70,6 +70,7 @@ fn default_python_config() -> PythonConfig {
         ("python_precompile", Value::Bool(true)),
         ("python_cross_platform", Value::Null),
         ("python_extra_index_url", Value::Null),
+        ("python_index_url", Value::Null),
         ("python_install_inputs", Value::Null),
         ("python_mcp_self_running", Value::Bool(false)),
     ] {

--- a/crates/anybuild/src/providers/python.rs
+++ b/crates/anybuild/src/providers/python.rs
@@ -146,6 +146,8 @@ pub struct PythonConfig {
     #[serde(rename = "python_cross_platform")]
     pub cross_platform: Option<String>,
     pub python_extra_index_url: Option<String>,
+    /// Default Python package index used for cross-platform resolution.
+    pub python_index_url: Option<String>,
     /// Derived install inputs for the Starlark provider (None => all files).
     #[serde(rename = "python_install_inputs")]
     pub install_inputs: Option<Vec<String>>,
@@ -175,6 +177,7 @@ impl Default for PythonConfig {
             precompile_python: true,
             cross_platform: None,
             python_extra_index_url: None,
+            python_index_url: None,
             install_inputs: None,
             mcp_self_running: false,
         }
@@ -225,6 +228,7 @@ impl PythonConfig {
             precompile_python: env_bool(operation, "python_precompile")?.unwrap_or(true),
             cross_platform: env_str(operation, "python_cross_platform"),
             python_extra_index_url: env_str(operation, "python_extra_index_url"),
+            python_index_url: env_str(operation, "python_index_url"),
             install_inputs: env_json(operation, "python_install_inputs")?,
             mcp_self_running: env_bool(operation, "python_mcp_self_running")?.unwrap_or(false),
         })

--- a/docs/anybuild-files.md
+++ b/docs/anybuild-files.md
@@ -152,7 +152,7 @@ sets — common fields `name`, `port`, and `app_subdir` live on the base):
 
 | Provider   | Fields                                                        |
 | ---------- | ------------------------------------------------------------- |
-| python     | `python_version`, `python_server`, `python_framework`, `asgi_application`, `wsgi_application`, `python_extra_dependencies`, `python_precompile`, `python_database`, `python_extra_index_url` |
+| python     | `python_version`, `python_server`, `python_framework`, `asgi_application`, `wsgi_application`, `python_extra_dependencies`, `python_precompile`, `python_database`, `python_index_url`, `python_extra_index_url` |
 | node       | `node_version`, `node_package_manager`, `node_framework`, `node_server`, `node_build_command`, `edgejs_enable`, `edgejs_precompile`, `optimize_node_dependencies` |
 | php        | `php_version`, `phpix`, `composer_enable`, `composer_build_script`, `php_public_dir` |
 | wordpress  | php fields plus `wp_version`, `wp_locale`, `wp_cli_version`    |

--- a/fixtures/manifest.json
+++ b/fixtures/manifest.json
@@ -98,6 +98,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [],
     "python_mcp_self_running": false,
     "static_convert_redirects": true,
@@ -139,6 +140,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [],
     "python_mcp_self_running": false,
     "static_convert_redirects": true,
@@ -177,6 +179,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -218,6 +221,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2593,6 +2597,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "pyproject.toml",
      "uv.lock",
@@ -2633,6 +2638,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "pyproject.toml",
      "uv.lock",
@@ -2670,6 +2676,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "pyproject.toml",
      "uv.lock",
@@ -2708,6 +2715,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "pyproject.toml",
      "uv.lock",
@@ -2745,6 +2753,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2781,6 +2790,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2818,6 +2828,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2856,6 +2867,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2893,6 +2905,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2931,6 +2944,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -2968,6 +2982,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "pyproject.toml",
      "uv.lock",
@@ -3008,6 +3023,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "pyproject.toml",
      "uv.lock",
@@ -3047,6 +3063,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3085,6 +3102,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3122,6 +3140,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3160,6 +3179,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3195,6 +3215,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3231,6 +3252,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3266,6 +3288,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [],
     "python_mcp_self_running": false
    },
@@ -3300,6 +3323,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [],
     "python_mcp_self_running": false
    }
@@ -3333,6 +3357,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3369,6 +3394,7 @@
     "python_precompile": true,
     "python_cross_platform": "wasix_wasm32",
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],
@@ -3491,6 +3517,7 @@
     "python_precompile": true,
     "python_cross_platform": null,
     "python_extra_index_url": null,
+    "python_index_url": null,
     "python_install_inputs": [
      "requirements.txt"
     ],

--- a/tests/plan_snapshots/python-django__cross.json
+++ b/tests/plan_snapshots/python-django__cross.json
@@ -48,7 +48,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile pyproject.toml --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile pyproject.toml --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "outputs": [
     "cross-requirements.txt"
    ]

--- a/tests/plan_snapshots/python-fastapi__cross.json
+++ b/tests/plan_snapshots/python-fastapi__cross.json
@@ -43,7 +43,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile pyproject.toml --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile pyproject.toml --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "outputs": [
     "cross-requirements.txt"
    ]

--- a/tests/plan_snapshots/python-fasthtml__cross.json
+++ b/tests/plan_snapshots/python-fasthtml__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],

--- a/tests/plan_snapshots/python-ffmpeg__cross.json
+++ b/tests/plan_snapshots/python-ffmpeg__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],

--- a/tests/plan_snapshots/python-flask__cross.json
+++ b/tests/plan_snapshots/python-flask__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],

--- a/tests/plan_snapshots/python-mcp-chatgpt__cross.json
+++ b/tests/plan_snapshots/python-mcp-chatgpt__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],

--- a/tests/plan_snapshots/python-mcp__cross.json
+++ b/tests/plan_snapshots/python-mcp__cross.json
@@ -48,7 +48,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile pyproject.toml --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile pyproject.toml --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "outputs": [
     "cross-requirements.txt"
    ]

--- a/tests/plan_snapshots/python-pandoc__cross.json
+++ b/tests/plan_snapshots/python-pandoc__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],

--- a/tests/plan_snapshots/python-pillow__cross.json
+++ b/tests/plan_snapshots/python-pillow__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],

--- a/tests/plan_snapshots/python-streamlit__cross.json
+++ b/tests/plan_snapshots/python-streamlit__cross.json
@@ -42,7 +42,7 @@
   },
   {
    "__type__": "RunStep",
-   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --index-url=https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
+   "command": "uv pip compile requirements.txt --python-version=3.13 --universal --extra-index-url None --default-index https://pypi.org/simple --emit-index-url --no-deps -o cross-requirements.txt",
    "inputs": [
     "requirements.txt"
    ],


### PR DESCRIPTION
Add `python_index_url` to select the fallback package index used while resolving cross-platform Python wheels. The default remains PyPI, and extra indexes retain uv's higher-priority semantics.

The field is available through provider configuration and the matching `ANYBUILD_PYTHON_INDEX_URL` environment setting.

The main purpose is to allow fully hermetic offline testing inside wasinix, that does not talk with the outside network at all.

Related Wasinix patch:
[python-index-url.patch](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/a/anybuild/python-index-url.patch)
