### PR TITLE
Update edgejs-quickjs to 0.2.0

### DIFF
--- a/crates/anybuild-cli/src/render.rs
+++ b/crates/anybuild-cli/src/render.rs
@@ -574,7 +574,7 @@ mod tests {
         let mappings = vec![
             WasmerPackageMapping {
                 source: "node@24".to_owned(),
-                target: "wasmer/edgejs-quickjs@=0.1.4".to_owned(),
+                target: "wasmer/edgejs-quickjs@=0.2.0".to_owned(),
             },
             WasmerPackageMapping {
                 source: "bash".to_owned(),
@@ -587,7 +587,7 @@ mod tests {
             concat!(
                 "  Mapping dependencies to Wasmer packages:\n",
                 "\n",
-                "  node@24  │  wasmer/edgejs-quickjs@=0.1.4\n",
+                "  node@24  │  wasmer/edgejs-quickjs@=0.2.0\n",
                 "  bash     │  wasmer/bash@=1.0.25\n",
             )
         );

--- a/crates/anybuild/src/run/wasmer.rs
+++ b/crates/anybuild/src/run/wasmer.rs
@@ -36,7 +36,7 @@ pub const ANYBUILD_VERSION_ANNOTATION: &str = "anybuild.run/version";
 pub const WASMER_APP_KIND_ANNOTATION: &str = "wasmer.io/app-kind";
 pub const WASMER_VERSION_ANNOTATION: &str = "wasmer.io/version";
 pub const BUILD_ANNOTATIONS_FILENAME: &str = "build-annotations.yaml";
-pub const EDGEJS_QUICKJS_DEPENDENCY: &str = "wasmer/edgejs-quickjs@=0.1.4";
+pub const EDGEJS_QUICKJS_DEPENDENCY: &str = "wasmer/edgejs-quickjs@=0.2.0";
 pub const PHPIX_VERSION: &str = "0.3.0-rc.5";
 pub const WASIX_PYTHON_INDEX_URL: &str = "https://python-registry.wasix.org/simple";
 const PREPARE_COMMAND_PREFIX: &str = "__anybuild_prepare_";
@@ -1703,7 +1703,7 @@ mod tests {
         let manifest = read_toml(&runner.wasmer_dir_path.join("wasmer.toml"));
         assert_eq!(
             manifest["dependencies"]["wasmer/edgejs-quickjs"].as_str(),
-            Some("=0.1.4")
+            Some("=0.2.0")
         );
         let command = manifest["command"]
             .as_array_of_tables()
@@ -2089,7 +2089,7 @@ mod tests {
              [package]\n\
              entrypoint = \"start\"\n\n\
              [dependencies]\n\
-             \"wasmer/edgejs-quickjs\" = \"=0.1.4\"\n\n\
+             \"wasmer/edgejs-quickjs\" = \"=0.2.0\"\n\n\
              [fs]\n\
              [[command]]\n\
              name = \"start\"\n\


### PR DESCRIPTION
## Summary

- update the Wasmer Node runtime mapping from wasmer/edgejs-quickjs 0.1.4 to 0.2.0
- update manifest-generation and CLI-rendering expectations

## Validation

- confirmed wasmer/edgejs-quickjs@0.2.0 exists in the Wasmer registry with the edge entrypoint
- cargo test --workspace
- Wasmer Express smoke with EdgeJS precompile: HTTP 200
- formatting, deny-warnings build, Clippy, units, snapshots, goldens, and CLI smoke passed through scripts/verify_rust.sh

## Note

The final external SDK-consumer step in scripts/verify_rust.sh is currently blocked on main because fixtures/sdk-consumer/Cargo.lock still pins local anybuild 0.27.2 while the workspace is 0.28.1. This PR does not change Cargo dependencies or that lockfile.